### PR TITLE
tidy up new toolbar item

### DIFF
--- a/RhythmboxRandomAlbumPlayer.py
+++ b/RhythmboxRandomAlbumPlayer.py
@@ -65,7 +65,7 @@ class RandomAlbumPlugin(GObject.Object, Peas.Activatable):
     self.action_group = ActionGroup(self.shell, 'RandomAlbumActionGroup')
     
     action = self.action_group.add_action_with_accel(func=self.random_album,
-    action_name='RandomAlbum', label='Play Random Album',
+    action_name='RandomAlbum', label='Random Album',
     action_type='app', action_state=ActionGroup.STANDARD,
     accel="<shift><ctrl>R")
 


### PR DESCRIPTION
Hi Javon,

  the new toolbar code broke RB2.99 and later  - so I fixed that for you.  Basically, you can't have toolbar menu items in RB2.99 and later since there is no-longer a ui-manager to poke stuff into.

Also I felt that the "Play Random Album" caused the toolbar button to be a bit too big compared to the other buttons - so I hope you dont mind, I've truncated the label so that the button size is reduced to something more reasonable.

As before - I've tested this on RB2.96 and RB3.0 and all looks ok.
